### PR TITLE
Добавлены принудительные состояния в машину состояний

### DIFF
--- a/Assets/Failsafe/Scripts/Behavior/BehaviorForcedState.cs
+++ b/Assets/Failsafe/Scripts/Behavior/BehaviorForcedState.cs
@@ -1,0 +1,24 @@
+
+/// <summary>
+/// Принудительное состояние
+/// Состояние, которое задается снаружи машины состояний
+/// </summary>
+public abstract class BehaviorForcedState : BehaviorState
+{
+    /// <summary>
+    /// Предыдущее состояние на момент переключения на это состояние
+    /// </summary>
+    protected BehaviorState _previousState;
+
+    /// <summary>
+    /// Вызывается в момент переключения на это состояние
+    /// </summary>
+    /// <param name="previousState">Предыдущее состояние на момент переключения на это состояние</param>
+    public virtual void Enter(BehaviorState previousState)
+    {
+        Enter();
+        _previousState = previousState;
+    }
+
+    public override abstract BehaviorState DecideNextState();
+}

--- a/Assets/Failsafe/Scripts/Behavior/BehaviorForcedState.cs.meta
+++ b/Assets/Failsafe/Scripts/Behavior/BehaviorForcedState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ec87d01209fa4746ace905843379ddc

--- a/Assets/Failsafe/Scripts/Behavior/BehaviorStateMachine.cs
+++ b/Assets/Failsafe/Scripts/Behavior/BehaviorStateMachine.cs
@@ -1,10 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
+
 public class BehaviorStateMachine
 {
     private BehaviorState _currentState;
+    private List<BehaviorForcedState> _forcedStates;
 
-    public BehaviorStateMachine(BehaviorState initState)
+    public BehaviorStateMachine(BehaviorState initState, List<BehaviorForcedState> forcedStates = null)
     {
         _currentState = initState;
+        _forcedStates = forcedStates ?? new List<BehaviorForcedState>();
     }
 
     /// <summary>
@@ -20,5 +25,28 @@ public class BehaviorStateMachine
             _currentState.Enter();
         }
         _currentState.Update();
+    }
+
+    /// <summary>
+    /// Переключение на принудительное состояние
+    /// </summary>
+    public void ForseChangeState<T>() where T : BehaviorForcedState
+    {
+        var nextState = _forcedStates.FirstOrDefault(x => x.GetType() == typeof(T));
+        if (nextState != null)
+        {
+            ForseChangeState(nextState);
+        }
+    }
+
+    private void ForseChangeState(BehaviorForcedState nextState)
+    {
+        if (nextState != _currentState)
+        {
+            var prevState = _currentState;
+            prevState.Exit();
+            _currentState = nextState;
+            nextState.Enter(prevState);
+        }
     }
 }

--- a/Assets/Failsafe/Scripts/Enemies/DisabledState.cs
+++ b/Assets/Failsafe/Scripts/Enemies/DisabledState.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+/// <summary>
+/// Состояние деактивации
+/// </summary>
+public class DisabledState : BehaviorForcedState
+{
+    private float _disableTime = 5f;
+    private float _disableProgress;
+
+    public override void Enter()
+    {
+        base.Enter();
+        _disableProgress = 0;
+        Debug.Log("Enter DisabledState");
+    }
+
+    public override void Update()
+    {
+        _disableProgress += Time.deltaTime;
+    }
+
+    public override BehaviorState DecideNextState()
+    {
+        if (_disableProgress < _disableTime) return this;
+        return _previousState;
+    }
+}

--- a/Assets/Failsafe/Scripts/Enemies/DisabledState.cs.meta
+++ b/Assets/Failsafe/Scripts/Enemies/DisabledState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 755e930715c14e447a37664716fb73f2

--- a/Assets/Failsafe/Scripts/Enemies/Enemy.cs
+++ b/Assets/Failsafe/Scripts/Enemies/Enemy.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AI;
 
@@ -17,11 +18,19 @@ public class Enemy : MonoBehaviour
         defaultState.AddTransition(chasingState, defaultState.PlayerSpoted);
         chasingState.AddTransition(defaultState, chasingState.PlayerLost);
 
-        _stateMachine = new BehaviorStateMachine(defaultState);
+        var disabledStates = new List<BehaviorForcedState>() { new DisabledState() };
+
+        _stateMachine = new BehaviorStateMachine(defaultState, disabledStates);
     }
 
     void Update()
     {
         _stateMachine.Update();
+    }
+
+    [ContextMenu("DisableState")]
+    public void DisableState()
+    {
+        _stateMachine.ForseChangeState<DisabledState>();
     }
 }


### PR DESCRIPTION
Принудительное состояние - cостояние, которое задается снаружи машины состояний. Например деактивация или взлом противника