### PR TITLE
Исправлено зацепление за уступы

### DIFF
--- a/Assets/Failsafe/Player/PlayerControllerTest.unity
+++ b/Assets/Failsafe/Player/PlayerControllerTest.unity
@@ -665,7 +665,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.2
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.z
@@ -677,7 +677,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2
+      value: 1.75
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1478,7 +1478,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.2
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.z
@@ -1490,7 +1490,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3
+      value: 2.75
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1556,7 +1556,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.2
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.z
@@ -1568,7 +1568,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1932,7 +1932,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.2
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.z
@@ -1944,7 +1944,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3120,7 +3120,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.2
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.z
@@ -3132,7 +3132,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.2
+      value: 3.9499998
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.z
@@ -5411,7 +5411,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.2
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalScale.z
@@ -5423,7 +5423,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3
+      value: 2.75
       objectReference: {fileID: 0}
     - target: {fileID: 7920147670680400448, guid: 3c88b8a9e33b0b246ad2b81132dbda52, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Failsafe/Player/PlayerMovements/Scripts/Input/InputHandler.cs
+++ b/Assets/Failsafe/Player/PlayerMovements/Scripts/Input/InputHandler.cs
@@ -24,6 +24,7 @@ public class InputHandler
     private const string _crouch = "Crouch";
     private const string _grabOrDrop = "GrabOrDrop";
     private const string _attack = "Attack";
+    private const string _grabLedge = "GrabLedge";
 
     private InputAction _movementAction;
     private InputAction _rotationAction;
@@ -32,6 +33,7 @@ public class InputHandler
     private InputAction _crouchAction;
     private InputAction _grabOrDropAction;
     private InputAction _attackAction;
+    private InputAction _grabLedgeAction;
 
     public Vector2 MovementInput { get; private set; }
     public bool MoveForward => MovementInput.y > 0;
@@ -39,8 +41,10 @@ public class InputHandler
     public Vector2 RotationInput { get; private set; }
     public bool JumpTriggered { get; private set; }
     public bool SprintTriggered { get; private set; }
-    public InputTrigger CrouchTrigger { get; private set; } = new InputTrigger(); public bool GrabOrDropTriggered { get; private set; }
+    public InputTrigger CrouchTrigger { get; private set; } = new InputTrigger();
+    public bool GrabOrDropTriggered { get; private set; }
     public bool AttackTriggered {get; private set;}
+    public InputTrigger GrabLedgeTrigger { get; private set; } = new InputTrigger();
 
 
     /// <summary>
@@ -64,6 +68,7 @@ public class InputHandler
         _crouchAction = mapReference.FindAction(_crouch);
         _grabOrDropAction = mapReference.FindAction(_grabOrDrop);
         _attackAction = mapReference.FindAction(_attack);
+        _grabLedgeAction = mapReference.FindAction(_grabLedge);
 
         SubscribeActionValuesToInputEvents();
     }
@@ -87,9 +92,12 @@ public class InputHandler
 
         _grabOrDropAction.performed += inputInfo => GrabOrDropTriggered = true;
         _grabOrDropAction.canceled += inputInfo => GrabOrDropTriggered = false;
-        
+
         _attackAction.performed += inputInfo => AttackTriggered = true;
         _attackAction.canceled += inputInfo => AttackTriggered = false;
+        
+        _grabLedgeAction.performed += GrabLedgeTrigger.OnInputStart;
+        _grabLedgeAction.canceled += GrabLedgeTrigger.OnInputCancel;
 
     }
     

--- a/Assets/Failsafe/Player/PlayerMovements/Scripts/Input/PlayerInput.cs
+++ b/Assets/Failsafe/Player/PlayerMovements/Scripts/Input/PlayerInput.cs
@@ -162,6 +162,15 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""GrabLedge"",
+                    ""type"": ""Button"",
+                    ""id"": ""72f2b72a-34fe-4387-800e-a343eb0a35a1"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -266,6 +275,17 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
                 },
                 {
                     ""name"": """",
+                    ""id"": ""8c2552b3-0478-4592-b1a4-46b5138cd0bf"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Crouch"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
                     ""id"": ""90bc8667-6231-48cb-963a-26939f05f9e5"",
                     ""path"": ""<Keyboard>/f"",
                     ""interactions"": """",
@@ -296,6 +316,17 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
                     ""action"": ""Attack"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""de594e4a-a68c-4eeb-8cd9-453bbe426c2d"",
+                    ""path"": ""<Keyboard>/space"",
+                    ""interactions"": ""Hold(pressPoint=0.1)"",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""GrabLedge"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
                 }
             ]
         }
@@ -312,6 +343,7 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
         m_Player_Use = m_Player.FindAction("Use", throwIfNotFound: true);
         m_Player_GrabOrDrop = m_Player.FindAction("GrabOrDrop", throwIfNotFound: true);
         m_Player_Attack = m_Player.FindAction("Attack", throwIfNotFound: true);
+        m_Player_GrabLedge = m_Player.FindAction("GrabLedge", throwIfNotFound: true);
     }
 
     ~@PlayerInput()
@@ -400,6 +432,7 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_Player_Use;
     private readonly InputAction m_Player_GrabOrDrop;
     private readonly InputAction m_Player_Attack;
+    private readonly InputAction m_Player_GrabLedge;
     /// <summary>
     /// Provides access to input actions defined in input action map "Player".
     /// </summary>
@@ -443,6 +476,10 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "Player/Attack".
         /// </summary>
         public InputAction @Attack => m_Wrapper.m_Player_Attack;
+        /// <summary>
+        /// Provides access to the underlying input action "Player/GrabLedge".
+        /// </summary>
+        public InputAction @GrabLedge => m_Wrapper.m_Player_GrabLedge;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -493,6 +530,9 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
             @Attack.started += instance.OnAttack;
             @Attack.performed += instance.OnAttack;
             @Attack.canceled += instance.OnAttack;
+            @GrabLedge.started += instance.OnGrabLedge;
+            @GrabLedge.performed += instance.OnGrabLedge;
+            @GrabLedge.canceled += instance.OnGrabLedge;
         }
 
         /// <summary>
@@ -528,6 +568,9 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
             @Attack.started -= instance.OnAttack;
             @Attack.performed -= instance.OnAttack;
             @Attack.canceled -= instance.OnAttack;
+            @GrabLedge.started -= instance.OnGrabLedge;
+            @GrabLedge.performed -= instance.OnGrabLedge;
+            @GrabLedge.canceled -= instance.OnGrabLedge;
         }
 
         /// <summary>
@@ -624,5 +667,12 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnAttack(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "GrabLedge" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnGrabLedge(InputAction.CallbackContext context);
     }
 }

--- a/Assets/Failsafe/Player/PlayerMovements/Scripts/Input/PlayerInput.inputactions
+++ b/Assets/Failsafe/Player/PlayerMovements/Scripts/Input/PlayerInput.inputactions
@@ -76,6 +76,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "GrabLedge",
+                    "type": "Button",
+                    "id": "72f2b72a-34fe-4387-800e-a343eb0a35a1",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -180,6 +189,17 @@
                 },
                 {
                     "name": "",
+                    "id": "8c2552b3-0478-4592-b1a4-46b5138cd0bf",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Crouch",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "90bc8667-6231-48cb-963a-26939f05f9e5",
                     "path": "<Keyboard>/f",
                     "interactions": "",
@@ -208,6 +228,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "Attack",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "de594e4a-a68c-4eeb-8cd9-453bbe426c2d",
+                    "path": "<Keyboard>/space",
+                    "interactions": "Hold(pressPoint=0.1)",
+                    "processors": "",
+                    "groups": "",
+                    "action": "GrabLedge",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Failsafe/Player/PlayerMovements/Scripts/PlayerController.cs
+++ b/Assets/Failsafe/Player/PlayerMovements/Scripts/PlayerController.cs
@@ -139,10 +139,10 @@ namespace Failsafe.PlayerMovements
             jumpState.AddTransition(runState, () => jumpState.CanGround() && _playerGravity.IsGrounded && _inputHandler.MoveForward && _inputHandler.SprintTriggered);
             jumpState.AddTransition(walkState, () => jumpState.CanGround() && _playerGravity.IsGrounded);
             jumpState.AddTransition(fallState, jumpState.InHightPoint);
-            jumpState.AddTransition(grabLedgeState, () => _ledgeController.CanGrabToLedgeGrabPointInView());
+            jumpState.AddTransition(grabLedgeState, () => _inputHandler.GrabLedgeTrigger.IsTriggered && _ledgeController.CanGrabToLedgeGrabPointInView());
 
             fallState.AddTransition(walkState, () => _playerGravity.IsGrounded);
-            fallState.AddTransition(grabLedgeState, () => _ledgeController.CanGrabToLedgeGrabPointInView());
+            fallState.AddTransition(grabLedgeState, () => _inputHandler.GrabLedgeTrigger.IsTriggered && _ledgeController.CanGrabToLedgeGrabPointInView());
 
             grabLedgeState.AddTransition(fallState, () => _inputHandler.MoveBack && grabLedgeState.CanFinish());
             grabLedgeState.AddTransition(climbingUpState, () => _inputHandler.MoveForward && grabLedgeState.CanFinish() && climbingUpState.CanClimb());


### PR DESCRIPTION
Цепляние за уступы происходит при зажатии пробела. (удерживать в течении 0,1 секунды) 
Нужно увеличить размер уступов чтобы было проще на них навестись (на тестовой сцене увеличил с 0,2 до 0,5 по оси Y) 
Также чтобы зацепится игрок должен смотреть на уступ под определенным углом (выставил до 60 градусов к нормали уступа) 
P.S.
Добавлена кнопка Ctrl для приседания