### PR TITLE
Исправлена сфера шума вокруг игрока

### DIFF
--- a/Assets/Failsafe/GameSceneServices/SignalSystem/PlayerNoiseSignal.cs
+++ b/Assets/Failsafe/GameSceneServices/SignalSystem/PlayerNoiseSignal.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using System;
 using UnityEngine;
 
@@ -15,8 +16,11 @@ public class PlayerNoiseSignal : ISignal
 
     public SignalType Type => SignalType.Noise;
     public Vector3 SourcePosition => _playerTransform.position;
-
     public float SignalStrength { get; private set; }
+
+    private float _targetStrength;
+    private float _decayPerSecond = 5f;
+    private UniTask _decayStrengthTask;
 
     /// <summary>
     /// Обновить силу издаваемого шума игроком
@@ -24,7 +28,25 @@ public class PlayerNoiseSignal : ISignal
     /// <param name="strength"></param>
     public void UpdateStrength(float strength)
     {
-        SignalStrength = strength;
+        _targetStrength = strength;
+        if (_targetStrength >= SignalStrength)
+        {
+            SignalStrength = _targetStrength;
+        }
+        else if (_decayStrengthTask.Status != UniTaskStatus.Pending)
+        {
+            _decayStrengthTask = DecayStrength();
+        }
+    }
+
+    private async UniTask DecayStrength()
+    {
+        while (_targetStrength < SignalStrength)
+        {
+            SignalStrength -= _decayPerSecond * Time.deltaTime;
+            await UniTask.Yield();
+        }
+        SignalStrength = _targetStrength;
     }
 
     public override string ToString() =>

--- a/Assets/Failsafe/Player/PlayerMovements/Scripts/PlayerStates/CrouchState.cs
+++ b/Assets/Failsafe/Player/PlayerMovements/Scripts/PlayerStates/CrouchState.cs
@@ -46,7 +46,6 @@ namespace Failsafe.PlayerMovements.States
         public override void Exit()
         {
             _playerBodyController.Stand();
-            _playerNoiseController.SetNoiseStrength(PlayerNoiseVolume.Default);
             _stepController.Disable();
         }
     }


### PR DESCRIPTION
Изменил сферу шума вокруг игрока, сделал так что при уменьшении шума сфера плавно угасает до нужного уровня. Сделано чтобы нельзя было абузить сенсор врага, двигаясь по чуть чуть с постоянными остановками.