### PR TITLE
Fix build errors: remove unused imports in ZoomEffect.cs

### DIFF
--- a/Assets/Failsafe/Player/Scripts/ZoomEffect.cs
+++ b/Assets/Failsafe/Player/Scripts/ZoomEffect.cs
@@ -1,8 +1,4 @@
-using Failsafe.PlayerMovements;
-using Sirenix.OdinInspector.Editor;
-using System;
 using UnityEngine;
-using UnityEngine.InputSystem;
 using VContainer;
 
 public class ZoomEffect : MonoBehaviour


### PR DESCRIPTION
Сейчас при билде выдает такую ошибку:
```
Assets/Failsafe/Player/Scripts/ZoomEffect.cs(2,29): error CS0234: The type or namespace name 'Editor' does not exist in the namespace 'Sirenix.OdinInspector' (are you missing an assembly reference?)
```

Odin никак не используется в ZoomEffect, просто удалил импорты оттуда - билд заработал


