### PR TITLE
Fix InputHandler: set GrabOrDropTriggered=false in LateTick()

### DIFF
--- a/Assets/Failsafe/Player/Scripts/Input/InputHandler.cs
+++ b/Assets/Failsafe/Player/Scripts/Input/InputHandler.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using VContainer.Unity;
 
 /// <summary>
 /// Класс работы с инпутом от игрока
 /// </summary>
-public class InputHandler
+public class InputHandler : ILateTickable
 {
     private readonly InputActionAsset _playerControls;
 
@@ -86,6 +87,11 @@ public class InputHandler
         _useAction = mapReference.FindAction(_use);
 
         SubscribeActionValuesToInputEvents();
+    }
+    
+    public void LateTick()
+    {
+        GrabOrDropTriggered = false;
     }
     
     private void SubscribeOnActionsPerformed()

--- a/Assets/Failsafe/Player/Scripts/PlayerLifetimeScope/PlayerLifetimeScope.cs
+++ b/Assets/Failsafe/Player/Scripts/PlayerLifetimeScope/PlayerLifetimeScope.cs
@@ -38,8 +38,8 @@ namespace Failsafe.Player
 
             builder.RegisterInstance(_playerCam);
 
-            builder.Register<InputHandler>(Lifetime.Scoped);
-
+            builder.RegisterEntryPoint<InputHandler>().AsSelf();
+            
             builder.Register<IHealth, PlayerHealth>(Lifetime.Singleton).AsSelf().WithParameter(_playerModelParameters.MaxHealth);
             builder.Register<IStamina, PlayerStamina>(Lifetime.Singleton).AsSelf().WithParameter(_playerModelParameters.MaxStamina);
             builder.RegisterEntryPoint<PlayerDamageable>(Lifetime.Scoped);


### PR DESCRIPTION
Можно проверить как работала кнопка `E` в сцене `TestMiniGame` до и после фикса:
- до: пока держишь `E`, компонент `interactable` продолжает без остановки вызываться
- после: `interactable` реагирует только на первое нажатие `E`


Нам желательно добавить все `IsTriggered = false` в `LateTick`, но я пока что не стал этого делать, чтобы много не ломать и много не тестировать, проверил только с `GrabOrDropTriggered`

Для истории, моё сообщение из дискорда:

> Нужно переделать InputHandler так, чтобы Triggered становился true только на один кадр, чтобы не нужно было в каждом месте костылить проверку самостоятельно
> 
> Для этого нужно как-то добавить в InputHandler что-то типо Update(), который будет сбрасывать все isTriggered в false
> 
> Чтобы isPressed у нас был проверкой продолжительной, типо нажата ли кнопка долго и держат ли её до сих пор (например, чтобы сидеть только при нажатой кнопке)
> 
> А isTriggered будет только для того, чтобы определить, нажата ли кнопка в этом кадре, чтобы только один раз на неё отреагировать и всё
> 
> Скорее всего нужно ITickable из VContainer взять и добавить в InputHandler
> 