### PR TITLE
Fix InputHandler: replace GrabOrDropTrigger with Action

### DIFF
--- a/Assets/Failsafe/Player/Scripts/Input/InputHandler.cs
+++ b/Assets/Failsafe/Player/Scripts/Input/InputHandler.cs
@@ -38,7 +38,7 @@ public class InputHandler
     private InputAction _jumpAction;
     private InputAction _sprintAction;
     private InputAction _crouchAction;
-    private InputAction _grabOrDropAction;
+    public InputAction GrabOrDropAction;
     private InputAction _attackAction;
     private InputAction _grabLedgeAction;
     private InputAction _zoomAction;
@@ -53,7 +53,6 @@ public class InputHandler
     public bool JumpTriggered { get; private set; }
     public bool SprintTriggered { get; private set; }
     public InputTrigger CrouchTrigger { get; private set; } = new InputTrigger();
-    public bool GrabOrDropTriggered { get; private set; }
     public bool AttackTriggered {get; private set;}
     public InputTrigger GrabLedgeTrigger { get; private set; } = new InputTrigger();
     public bool ZoomTriggered {get; private set;} 
@@ -79,7 +78,7 @@ public class InputHandler
         _jumpAction = mapReference.FindAction(_jump);
         _sprintAction = mapReference.FindAction(_sprint);
         _crouchAction = mapReference.FindAction(_crouch);
-        _grabOrDropAction = mapReference.FindAction(_grabOrDrop);
+        GrabOrDropAction = mapReference.FindAction(_grabOrDrop);
         _attackAction = mapReference.FindAction(_attack);
         _grabLedgeAction = mapReference.FindAction(_grabLedge);
         _zoomAction = mapReference.FindAction(_zoom);
@@ -125,9 +124,6 @@ public class InputHandler
 
         _crouchAction.performed += CrouchTrigger.OnInputStart;
         _crouchAction.canceled += CrouchTrigger.OnInputCancel;
-
-        _grabOrDropAction.performed += inputInfo => GrabOrDropTriggered = true;
-        _grabOrDropAction.canceled += inputInfo => GrabOrDropTriggered = false;
 
         _attackAction.performed += inputInfo => AttackTriggered = true;
         _attackAction.canceled += inputInfo => AttackTriggered = false;

--- a/Assets/Failsafe/Player/Scripts/Interaction/PhysicsInteraction.cs
+++ b/Assets/Failsafe/Player/Scripts/Interaction/PhysicsInteraction.cs
@@ -50,7 +50,6 @@ namespace Failsafe.Player.Scripts.Interaction
         private float _throwForceMultiplier;
         private const float _maxForceMultiplier = 3f;
 
-        private bool _allowToGrabOrDrop = true;
         private int _cachedCarryingLayer;
 
 
@@ -78,13 +77,9 @@ namespace Failsafe.Player.Scripts.Interaction
         private void Update()
         {
             UpdateCrosshairScale();
-            if (_inputHandler.GrabOrDropTriggered && _allowToGrabOrDrop)
+            if (_inputHandler.GrabOrDropAction.WasPressedThisFrame())
             {
                 GrabOrDrop();
-            }
-            else if (!_inputHandler.GrabOrDropTriggered)
-            {
-                _allowToGrabOrDrop = true;
             }
 
             if (IsDragging)
@@ -121,7 +116,6 @@ namespace Failsafe.Player.Scripts.Interaction
 
         public void GrabOrDrop()
         {
-            _allowToGrabOrDrop = false;
 
             if (!CarryingObject)
             {

--- a/Assets/Failsafe/Scripts/interaction System/PlayerInteraction.cs
+++ b/Assets/Failsafe/Scripts/interaction System/PlayerInteraction.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine.UI;
 using VContainer;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 public class PlayerInteraction: MonoBehaviour
 {
@@ -17,13 +18,13 @@ public class PlayerInteraction: MonoBehaviour
     [SerializeField] private float _scaleSpeed = 8f;
 
     private float _normalSize;
-    private bool _allowToInteract = true;
 
     void Start()
     {
         _normalSize = _crosshairImage.transform.localScale.x;
     }
 
+    
     void Update()
     {
         float targetScale = _normalSize;
@@ -36,14 +37,9 @@ public class PlayerInteraction: MonoBehaviour
             if(hitInfo.collider.GetComponent<Interactable>() != null)
             {
                 Interactable interactable = hitInfo.collider.GetComponent<Interactable>();
-                if (_inputHandler.GrabOrDropTriggered && _allowToInteract) //использовал триггер GrapOrDrop так как не смг создать свой
+                if (_inputHandler.GrabOrDropAction.WasPressedThisFrame()) //использовал триггер GrapOrDrop так как не смг создать свой
                 {
-                    _allowToInteract = false;
                     interactable.BaseInteract();
-                }
-                else if (!_inputHandler.UseTriggered)
-                {
-                    _allowToInteract = true;
                 }
                 targetScale = _hoverSize;
             }


### PR DESCRIPTION
Можно проверить как работала кнопка `E` в сцене `TestMiniGame` до и после фикса:
- до: пока держишь `E`, компонент `interactable` продолжает без остановки вызываться
- после: `interactable` реагирует только на первое нажатие `E`

После ПРа https://github.com/onirise/Failsafe/pull/196 обсудили, с @trofimoved, что проблем с чтением инпутов в фреймах нет, но нам не нужно самим имплементировать систему обработки инпутов и для нашего юз-кейса уже есть готовое решение `InputSystem` - в нём уже есть методы для проверки, что Action был вызван в текущем фрейме

Для этого я сделал `GrabOrDropAction` публичным и удалил `GrabOrDropTrigger`, так как он больше не использовался. Поменял код в тех местах, где проверялся `GrabOrDropTrigger` и добавлялась дополнительная логика для обработки его только в одном фрейме - удалил ненужную логику

Считаем, что класс InputHandler используется только для специфичной обработки инпутов, где нужна задержка в обработки в несколько фреймов (буфферизация) и в InputHandler используется один Trigger на одного обработчика

