### PR TITLE
Hotfix: add AsSelf() and change register order in PlayerLifetimeScope

### DIFF
--- a/Assets/Failsafe/Player/Scripts/PlayerLifetimeScope/PlayerLifetimeScope.cs
+++ b/Assets/Failsafe/Player/Scripts/PlayerLifetimeScope/PlayerLifetimeScope.cs
@@ -47,11 +47,12 @@ namespace Failsafe.Player
 
             builder.RegisterEntryPoint<PlayerController>(Lifetime.Scoped).AsSelf();
 
+            builder.Register<PlayerHandsContainer>(Lifetime.Scoped);
+            builder.RegisterEntryPoint<PlayerHandsSystem>(Lifetime.Scoped).AsSelf();
+            
             builder.RegisterEntryPoint<PlayerAnimationController>(Lifetime.Scoped);
             builder.RegisterEntryPoint<PlayerCameraController>(Lifetime.Scoped);
 
-            builder.Register<PlayerHandsContainer>(Lifetime.Scoped);
-            builder.RegisterEntryPoint<PlayerHandsSystem>(Lifetime.Scoped);
 
             RegisterItems(builder);
         }


### PR DESCRIPTION
После сегодняшних мержей что-то сломалось, сцена `DataCenter` не стартовала, выдавала ошибку:
```
VContainerException: Failed to resolve Failsafe.Player.PlayerAnimationController : No such registration of type: PlayerHandsSystem
```

Переместил регистрацию `PlayerHandsSystem` выше `PlayerAnimationController` и добавил `.AsSelf()`